### PR TITLE
fix(auth): reroute openrouter api endpoints

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
         env:
-          ANTHROPIC_BASE_URL: https://openrouter.ai/api
+          ANTHROPIC_BASE_URL: https://openrouter.ai/api/v1
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
         env:
-          ANTHROPIC_BASE_URL: https://openrouter.ai/api
+          ANTHROPIC_BASE_URL: https://openrouter.ai/api/v1
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR change? -->
Reroute OpenRouter API endpoints to use the v1 path. This ensures that all requests to the Claude/OpenRouter service are compatible with the current OpenRouter API version.

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->
The previous endpoints were either outdated or incompatible with the latest OpenRouter API, which could cause failed requests or errors in workflows that rely on AI services. Updating to the v1 endpoints ensures stable integration and avoids API errors.

## Areas touched

<!-- Check all that apply -->

- [ ] .claude (plugins / core / skills / MCP server)
- [ ] mirabile web (browser UI / config / model / routes / extensions)
- [ ] client (api / database / components / pages / utils)
- [x] CI / GitHub Actions
- [ ] Documentation / developer experience

## Scope & constraints

**In scope**

- <!-- bullets -->Update OpenRouter API endpoints in workflows and any relevant environment variables.
- Ensure that AI-based workflows (e.g., Claude code review) continue to function properly.

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->Changes to AI models, workflow logic, or repository code beyond the API endpoint updates.

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->
- Updated ANTHROPIC_BASE_URL in GitHub Actions workflows to https://openrouter.ai/api/v1.
- Verified that existing steps that send prompts to Claude/OpenRouter continue to work with the new base URL.

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] **Client dev server** — `cd client && npm start` — app loads on http://localhost:3000
- [ ] **Client tests** — `cd client && npm test -- --watchAll=false` — all tests pass
- [ ] **Client build** — `cd client && npm run build` — production build succeeds
- [ ] **Server start** — `cd server && node index.js` — API starts on port 5000
- [ ] **API smoke test** — `curl http://localhost:5000/api/message` — expected response
- [x] Workflow runs triggered by PR and issue comments successfully hit OpenRouter v1 endpoints.
- [x] Existing CI steps and AI review tasks function as expected.
- [ ] Manual verification of AI responses in PR comments.
## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->
Minor risk: workflows depending on OpenRouter may temporarily fail if endpoint changes are misconfigured.
Rollout: Update all workflows and environment variables referencing the old API endpoints.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed