### PR TITLE
fix(cli): resolve endless loop triggered on wrong condition

### DIFF
--- a/.github/workflows/mirabile_assign_issue.yml
+++ b/.github/workflows/mirabile_assign_issue.yml
@@ -39,7 +39,7 @@ jobs:
           permission-issues: 'write'
 
       - name: 'Assign issue to user'
-        if: contains(github.event.comment.body, 'assign')
+        if: "contains(github.event.comment.body, '/assign')"
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd'
         with:
           github-token: '${{ steps.generate_token.outputs.token }}'
@@ -49,22 +49,6 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const MAX_ISSUES_ASSIGNED = 3;
-            
-            const commentBody = context.payload.comment.body.trim();
-      
-            if (
-              commentBody.includes('assign') &&
-              commentBody !== '/assign' &&
-              !commentBody.startsWith('/unassign')
-            ) {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body: ` @${commenter} please use \`/assign\` to assign yourself to this issue.`
-              });
-              return;
-            }
             
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR change? -->
This pr resolve an issue with Mirabile cli stuck in an endless comment loop triggered due to an await error in the CreateIssueComment step
fix #25 

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] .claude (plugins / core / skills / MCP server)
- [ ] mirabile web (browser UI / config / model / routes / extensions)
- [ ] client (api / database / components / pages / utils)
- [x] CI / GitHub Actions
- [ ] Documentation / developer experience

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] **Client dev server** — `cd client && npm start` — app loads on http://localhost:3000
- [ ] **Client tests** — `cd client && npm test -- --watchAll=false` — all tests pass
- [ ] **Client build** — `cd client && npm run build` — production build succeeds
- [ ] **Server start** — `cd server && node index.js` — API starts on port 5000
- [ ] **API smoke test** — `curl http://localhost:5000/api/message` — expected response

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed