### PR TITLE
feat: set up cli entry point with executable commands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# By default, require reviews from the maintainers for all files.
+* @mirabile-mira/mira-cli-maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: 'Bug Report'
+description: 'Report a bug to help us improve Mira CLI'
+body:
+  - type: 'markdown'
+    attributes:
+      value: |-
+        > [!IMPORTANT]
+        > Thanks for taking the time to fill out this bug report!
+        >
+        > Please search **[existing issues](https://github.com/mirabile-mira/mira-cli/issues)** to see if an issue already exists for the bug you encountered.
+
+  - type: 'textarea'
+    id: 'problem'
+    attributes:
+      label: 'What happened?'
+      description: 'A clear and concise description of what the bug is.'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'expected'
+    attributes:
+      label: 'What did you expect to happen?'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'info'
+    attributes:
+      label: 'Client information'
+      description: 'Please paste the full text from the `/about` command run from Mira CLI. Also include which platform (macOS, Windows, Linux). Note that this output contains your email address. Consider removing it before submitting.'
+      value: |-
+        <details>
+        <summary>Client Information</summary>
+
+        Run `mira` to enter the interactive CLI, then run the `/about` command.
+
+        ```console
+        > /about
+        # paste output here
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'login-info'
+    attributes:
+      label: 'Login information'
+      description: 'Describe how you are logging in (e.g., Mirabile account, Google Account, Github Account).'
+
+  - type: 'textarea'
+    id: 'additional-context'
+    attributes:
+      label: 'Anything else we need to know?'
+      description: 'Add any other context about the problem here.'

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: 'Feature Request'
+description: 'Suggest an idea for this project'
+labels:
+  - 'status/need-triage'
+type: 'Feature'
+body:
+  - type: 'markdown'
+    attributes:
+      value: |-
+        > [!IMPORTANT]
+        > Thanks for taking the time to suggest an enhancement!
+        >
+        > Please search **[existing issues](https://github.com/mirabile-mira/mira-cli/issues)** to see if a similar feature has already been requested.
+
+  - type: 'textarea'
+    id: 'feature'
+    attributes:
+      label: 'What would you like to be added?'
+      description: 'A clear and concise description of the enhancement.'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'rationale'
+    attributes:
+      label: 'Why is this needed?'
+      description: 'A clear and concise description of why this enhancement is needed.'
+    validations:
+      required: true
+
+  - type: 'textarea'
+    id: 'additional-context'
+    attributes:
+      label: 'Additional context'
+      description: 'Add any other context or screenshots about the feature request here.'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    groups:
+      actions-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- Concisely describe what this PR changes and why. Focus on impact and
+urgency. -->
+
+## Details
+
+<!-- Add any extra context and design decisions. Keep it brief but complete. -->
+
+## Related Issues
+
+<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
+only related to an issue or is a partial fix, simply reference the issue number
+without a keyword (Related to #123). -->
+
+## How to Validate
+
+<!-- List exact steps for reviewers to validate the change. Include commands,
+expected results, and edge cases. -->
+
+## Pre-Merge Checklist
+
+<!-- Check all that apply before requesting review or merging. -->
+
+- [ ] Updated relevant documentation and README (if needed)
+- [ ] Added/updated tests (if needed)
+- [ ] Noted breaking changes (if any)
+- [ ] Validated on required platforms/methods:
+  - [ ] MacOS
+    - [ ] npm run
+    - [ ] npx
+    - [ ] Docker
+    - [ ] Podman
+    - [ ] Seatbelt
+  - [ ] Windows
+    - [ ] npm run
+    - [ ] npx
+    - [ ] Docker
+  - [ ] Linux
+    - [ ] npm run
+    - [ ] npx
+    - [ ] Docker

--- a/package-lock.json
+++ b/package-lock.json
@@ -8364,9 +8364,22 @@
       "name": "@mira/cli",
       "version": "0.1.0",
       "dependencies": {
-        "@mira/auth": "^0.1.0",
-        "@mira/core": "^0.1.0",
-        "@mira/shared": "^0.1.0"
+        "@mira/auth": "*",
+        "@mira/core": "*",
+        "@mira/shared": "*",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "mira": "bin/mira"
+      }
+    },
+    "packages/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/core": {

--- a/packages/cli/bin/mira
+++ b/packages/cli/bin/mira
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/index.js');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,13 +4,19 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
+  "bin": {
+    "mira": "./bin/mira"
+  },
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mira/auth": "^0.1.0",
-    "@mira/core": "^0.1.0",
-    "@mira/shared": "^0.1.0"
+    "@mira/auth": "*",
+    "@mira/core": "*",
+    "@mira/shared": "*",
+    "commander": "^12.1.0"
   }
 }

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,0 +1,8 @@
+export interface agentOptions {
+    model? : string;
+    dryRun? : boolean;
+}
+
+export async function runAgent(task: string | undefined, options: agentOptions): Promise<void> {
+    console.log("TODO: Implement agent", task, options);
+}

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -1,0 +1,8 @@
+export interface ChatOptions {
+    model? : string;
+    stream? : boolean;
+}
+
+export async function runChat(options: ChatOptions): Promise<void> {
+    console.log("TODO: Implement chat", options);
+}

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,11 @@
+export async function runConfigGet(key: string): Promise<void> {
+  console.log("TODO: get config", key);
+}
+ 
+export async function runConfigSet(key: string, value: string): Promise<void> {
+  console.log("TODO: set config", key, value);
+}
+ 
+export async function runConfigList(): Promise<void> {
+  console.log("TODO: list config");
+}

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,0 +1,7 @@
+export interface loginOptions {
+    token? : string;
+}
+
+export async function runLogin(options: loginOptions): Promise<void> {
+    console.log("TODO: implement login", options)
+}

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,0 +1,3 @@
+export async function runLogout(): Promise<void> {
+    console.log("TODO: implement logout");
+}

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,7 @@
+export async function runMcpList(): Promise<void> {
+  console.log("TODO: list MCP servers");
+}
+ 
+export async function runMcpAdd(server: string): Promise<void> {
+  console.log("TODO: add MCP server", server);
+}

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -1,0 +1,11 @@
+export async function runPluginList(): Promise<void> {
+  console.log("TODO: list plugins");
+}
+ 
+export async function runPluginInstall(name: string): Promise<void> {
+  console.log("TODO: install plugin", name);
+}
+ 
+export async function runPluginRemove(name: string): Promise<void> {
+  console.log("TODO: remove plugin", name);
+}

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -1,0 +1,7 @@
+export async function runSkillList(): Promise<void> {
+  console.log("TODO: list skills");
+}
+ 
+export async function runSkillAdd(name: string): Promise<void> {
+  console.log("TODO: add skill", name);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,170 @@
+import { Command } from "commander";
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+ 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+ 
+// Read version from package.json at runtime
+const { version } = require("../package.json") as { version: string };
+
+const program = new Command();
+
+program
+.name('mira')
+.description("An AI agent that lives inside your terminal")
+.version(version, "-v, --version", "Print the current mira-cli version")
+.helpOption("-h, --help", "Display help for command")
+.addHelpText(
+"after",
+    `
+Examples:
+  $ mira chat                    Start an interactive AI chat session
+  $ mira agent run ./task.md     Run an autonomous agent task
+  $ mira login                   Authenticate with the Mira platform
+  $ mira config set model gpt-4  Set a configuration value
+    `
+);
+
+program
+  .command("chat")
+  .description("Start an interactive AI chat session in your terminal")
+  .option("-m, --model <model>", "Model to use for the session")
+  .option("--no-stream", "Disable streaming output")
+  .action(async (options) => {
+    const { runChat } = await import("./commands/chat.js");
+    await runChat(options);
+  });
+ 
+program
+  .command("agent")
+  .description("Run an autonomous AI agent")
+  .argument("[task]", "Task description or path to a task file")
+  .option("--dry-run", "Preview actions without executing them")
+  .option("-m, --model <model>", "Model to use for the agent")
+  .action(async (task, options) => {
+    const { runAgent } = await import("./commands/agent.js");
+    await runAgent(task, options);
+  });
+ 
+program
+  .command("login")
+  .description("Authenticate with the Mira platform")
+  .option("--token <token>", "Provide an API token directly (non-interactive)")
+  .action(async (options) => {
+    const { runLogin } = await import("./commands/login.js");
+    await runLogin(options);
+  });
+ 
+program
+  .command("logout")
+  .description("Log out and clear stored credentials")
+  .action(async () => {
+    const { runLogout } = await import("./commands/logout.js");
+    await runLogout();
+  });
+ 
+const plugin = program
+  .command("plugin")
+  .description("Manage mira plugins");
+ 
+plugin
+  .command("list")
+  .description("List installed plugins")
+  .action(async () => {
+    const { runPluginList } = await import("./commands/plugin.js");
+    await runPluginList();
+  });
+ 
+plugin
+  .command("install <name>")
+  .description("Install a plugin")
+  .action(async (name) => {
+    const { runPluginInstall } = await import("./commands/plugin.js");
+    await runPluginInstall(name);
+  });
+ 
+plugin
+  .command("remove <name>")
+  .description("Remove a plugin")
+  .action(async (name) => {
+    const { runPluginRemove } = await import("./commands/plugin.js");
+    await runPluginRemove(name);
+  });
+ 
+const skill = program
+  .command("skill")
+  .description("Manage agent skills");
+ 
+skill
+  .command("list")
+  .description("List available skills")
+  .action(async () => {
+    const { runSkillList } = await import("./commands/skill.js");
+    await runSkillList();
+  });
+ 
+skill
+  .command("add <name>")
+  .description("Add a skill to the agent")
+  .action(async (name) => {
+    const { runSkillAdd } = await import("./commands/skill.js");
+    await runSkillAdd(name);
+  });
+ 
+const mcp = program
+  .command("mcp")
+  .description("Manage Model Context Protocol servers");
+ 
+mcp
+  .command("list")
+  .description("List configured MCP servers")
+  .action(async () => {
+    const { runMcpList } = await import("./commands/mcp.js");
+    await runMcpList();
+  });
+ 
+mcp
+  .command("add <server>")
+  .description("Register an MCP server")
+  .action(async (server) => {
+    const { runMcpAdd } = await import("./commands/mcp.js");
+    await runMcpAdd(server);
+  });
+ 
+const config = program
+  .command("config")
+  .description("View and set mira configuration");
+ 
+config
+  .command("get <key>")
+  .description("Get a config value")
+  .action(async (key) => {
+    const { runConfigGet } = await import("./commands/config.js");
+    await runConfigGet(key);
+  });
+ 
+config
+  .command("set <key> <value>")
+  .description("Set a config value")
+  .action(async (key, value) => {
+    const { runConfigSet } = await import("./commands/config.js");
+    await runConfigSet(key, value);
+  });
+ 
+config
+  .command("list")
+  .description("List all config values")
+  .action(async () => {
+    const { runConfigList } = await import("./commands/config.js");
+    await runConfigList();
+  });
+ 
+program.on("command:*", (operands: string[]) => {
+  console.error(`\n  error: unknown command '${operands[0]}'\n`);
+  console.error(`  Run 'mira --help' to see available commands.\n`);
+  process.exitCode = 1;
+});
+ 
+program.parse(process.argv);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "declaration": true,
     "declarationMap": true,
 
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    "types": [
+      "node"
+    ]
   },
 
   "files": [],


### PR DESCRIPTION
## Summary

Sets up the CLI entry point for `mira-cli` using Commander.js. Registers all top-level commands
with stub handlers, wires up `--version` and `--help`, and adds a friendly unknown command error.
This is scaffolding only — actual agent behaviour will be implemented in later issues.

## Details

- Installs `commander` as a dependency of `@mira/cli`
- Creates `packages/cli/src/index.ts` as the main program entry point
- Registers top-level commands: `chat`, `agent`, `login`, `logout`, `plugin`, `skill`, `mcp`, `config`
- Sub-commands scoped under each group (e.g. `plugin install`, `config set`, `mcp add`)
- `--version` reads from `package.json` at runtime
- `--help` includes a formatted examples block
- Unknown commands print a friendly error and exit with code 1
- All command handlers are stub imports from `src/commands/*.ts` — no real logic yet
- Adds `bin/mira` entry and registers it in `package.json`

## Related Issues

Closes #33
Related to #31

## How to Validate

1. Build the package
```bash
cd packages/cli
npx tsc
```

2. Help output
```bash
node dist/index.js --help
```
Expected: all 8 commands listed with descriptions and examples block.

3. Version flag
```bash
node dist/index.js --version
```
Expected: `0.1.0`

4. Unknown command
```bash
node dist/index.js unknowncommand
```
Expected:
```
  error: unknown command 'unknowncommand'
  Run 'mira --help' to see available commands.
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker